### PR TITLE
Fix docs link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 > The easiest way to develop apps for Windows.
 
-[Read the Docs](https://fresh2.dev/doc/anybox/)
+[Read the Docs!](https://www.fresh2.dev/r/anybox/)


### PR DESCRIPTION
I hope i did this pull request right... all I did was make the "Read the Docs" link on the readme go to the new valid page